### PR TITLE
kvdpa: return an interface instead of struct

### DIFF
--- a/cmd/kvdpa-cli/kvdpa-cli.go
+++ b/cmd/kvdpa-cli/kvdpa-cli.go
@@ -27,7 +27,7 @@ func getAction(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s : %+v\n", pci, *dev)
+		fmt.Printf("%s : %+v\n", pci, dev)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR makes the interface to the library much more usable by exposing an interface instead of the underlying struct