### PR TITLE
kvdpa: rename GetParent->GetName

### DIFF
--- a/pkg/kvdpa/kvdpa.go
+++ b/pkg/kvdpa/kvdpa.go
@@ -26,7 +26,7 @@ const (
 /*VdpaDevice contains information about a Vdpa Device*/
 type VdpaDevice interface {
 	GetDriver() string
-	GetParent() string
+	GetName() string
 	GetPath() string
 	GetNetDev() string
 }
@@ -43,7 +43,7 @@ func (vd *vdpaDev) GetDriver() string {
 	return vd.driver
 }
 
-func (vd *vdpaDev) GetParent() string {
+func (vd *vdpaDev) GetName() string {
 	return vd.name
 }
 


### PR DESCRIPTION
The fact that we're returning the vdpa device name with GetParent() is
confusing. Right, it's the parent from the virtio/vhost PoV but from the
point of view of the vdpa device, it's confusing.

So, rename GetParent() -> GetName() in preparation for proper parent
handling.

Signed-off-by: Adrian Moreno <amorenoz@redhat.com>