### PR TITLE
add/remove VDPA devices

### DIFF
--- a/cmd/kvdpa-cli/kvdpa-cli.go
+++ b/cmd/kvdpa-cli/kvdpa-cli.go
@@ -72,6 +72,18 @@ func getAction(c *cli.Context) error {
 	return nil
 }
 
+func addAction(c *cli.Context) error {
+	if c.Args().Len() != 2 {
+		err := cli.ShowAppHelp(c)
+		return err
+	}
+
+	mgmtDevName := c.Args().Get(0)
+	devName := c.Args().Get(1)
+
+	return vdpa.AddVdpaDevice(mgmtDevName, devName)
+}
+
 func main() {
 	app := &cli.App{
 		Name:  "kvdpa-cli",
@@ -92,8 +104,14 @@ func main() {
 				Action:    getAction,
 				ArgsUsage: "[name]",
 			},
+			{Name: "add",
+				Usage:     "Add a new vdpa device",
+				Action:    addAction,
+				ArgsUsage: "[mgmtdev] [dev]",
+			},
 		},
 	}
+
 	err := app.Run(os.Args)
 	if err != nil {
 		fmt.Println(err)

--- a/cmd/kvdpa-cli/kvdpa-cli.go
+++ b/cmd/kvdpa-cli/kvdpa-cli.go
@@ -84,6 +84,17 @@ func addAction(c *cli.Context) error {
 	return vdpa.AddVdpaDevice(mgmtDevName, devName)
 }
 
+func deleteAction(c *cli.Context) error {
+	if c.Args().Len() != 1 {
+		err := cli.ShowAppHelp(c)
+		return err
+	}
+
+	devName := c.Args().Get(0)
+
+	return vdpa.DeleteVdpaDevice(devName)
+}
+
 func main() {
 	app := &cli.App{
 		Name:  "kvdpa-cli",
@@ -108,6 +119,11 @@ func main() {
 				Usage:     "Add a new vdpa device",
 				Action:    addAction,
 				ArgsUsage: "[mgmtdev] [dev]",
+			},
+			{Name: "del",
+				Usage:     "Delete a vdpa device",
+				Action:    deleteAction,
+				ArgsUsage: "[dev]",
 			},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/vishvananda/netlink v1.1.0
+	golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444
 )
 
 require (
@@ -16,6 +17,5 @@ require (
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/objx v0.1.0 // indirect
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect
-	golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/pkg/kvdpa/device.go
+++ b/pkg/kvdpa/device.go
@@ -282,6 +282,25 @@ func AddVdpaDevice(mgmtDeviceName string, vdpaDeviceName string) error {
 	return nil
 }
 
+/*DeleteVdpaDevice deletes a vdpa device */
+func DeleteVdpaDevice(vdpaDeviceName string) error {
+	if vdpaDeviceName == "" {
+		return unix.EINVAL
+	}
+
+	nameAttr, err := GetNetlinkOps().NewAttribute(VdpaAttrDevName, vdpaDeviceName)
+	if err != nil {
+		return err
+	}
+
+	_, err = GetNetlinkOps().RunVdpaNetlinkCmd(VdpaCmdDevDel, unix.NLM_F_ACK|unix.NLM_F_REQUEST, []*nl.RtAttr{nameAttr})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func parseDevLinkVdpaDevList(msgs [][]byte) ([]VdpaDevice, error) {
 	devices := make([]VdpaDevice, 0, len(msgs))
 

--- a/pkg/kvdpa/device.go
+++ b/pkg/kvdpa/device.go
@@ -241,6 +241,22 @@ func extractBusNameAndMgmtDeviceName(fullMgmtDeviceName string) (busName string,
 	}
 }
 
+/*
+GetVdpaDevicesByPciAddress returns the VdpaDevice objects for the given pciAddress
+
+	The pciAddress must have one of the following formats:
+	- MgmtBusName/MgmtDevName
+	- MgmtDevName
+*/
+func GetVdpaDevicesByPciAddress(pciAddress string) ([]VdpaDevice, error) {
+	busName, mgmtDeviceName, err := extractBusNameAndMgmtDeviceName(pciAddress)
+	if err != nil {
+		return nil, unix.EINVAL
+	}
+
+	return GetVdpaDevicesByMgmtDev(busName, mgmtDeviceName)
+}
+
 /*AddVdpaDevice adds a new vdpa device to the given management device */
 func AddVdpaDevice(mgmtDeviceName string, vdpaDeviceName string) error {
 	if mgmtDeviceName == "" || vdpaDeviceName == "" {

--- a/pkg/kvdpa/device.go
+++ b/pkg/kvdpa/device.go
@@ -1,11 +1,14 @@
 package kvdpa
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
 )
 
 // Exported constants
@@ -144,17 +147,22 @@ func (vd *vdpaDev) ParentDevicePath() (string, error) {
 	return parent, nil
 }
 
-/* Finds the virtio vdpa device of a vdpa device and returns its path
+/*
+	Finds the virtio vdpa device of a vdpa device and returns its path
+
 Currently, PCI-based devices have the following sysfs structure:
 /sys/bus/vdpa/devices/
-    vdpa1 -> ../../../devices/pci0000:00/0000:00:03.2/0000:05:00.2/vdpa1
+
+	vdpa1 -> ../../../devices/pci0000:00/0000:00:03.2/0000:05:00.2/vdpa1
 
 In order to find the virtio device we look for virtio* devices inside the parent device:
+
 	sys/devices/pci0000:00/0000:00:03.2/0000:05:00.2/virtio{N}
 
 We also check the virtio device exists in the virtio bus:
 /sys/bus/virtio/devices
-    virtio{N} -> ../../../devices/pci0000:00/0000:00:03.2/0000:05:00.2/virtio{N}
+
+	virtio{N} -> ../../../devices/pci0000:00/0000:00:03.2/0000:05:00.2/virtio{N}
 */
 func (vd *vdpaDev) getVirtioVdpaDev() (VirtioNet, error) {
 	parentPath, err := vd.ParentDevicePath()
@@ -184,7 +192,8 @@ func GetVdpaDevice(name string) (VdpaDevice, error) {
 	return vdpaDevs[0], nil
 }
 
-/*GetVdpaDevicesByMgmtDev returns the VdpaDevice objects whose MgmtDev
+/*
+GetVdpaDevicesByMgmtDev returns the VdpaDevice objects whose MgmtDev
 has the given bus and device names.
 */
 func GetVdpaDevicesByMgmtDev(busName, devName string) ([]VdpaDevice, error) {
@@ -218,6 +227,59 @@ func ListVdpaDevices() ([]VdpaDevice, error) {
 		return nil, err
 	}
 	return vdpaDevs, nil
+}
+
+func extractBusNameAndMgmtDeviceName(fullMgmtDeviceName string) (busName string, mgmtDeviceName string, err error) {
+	numSlashes := strings.Count(fullMgmtDeviceName, "/")
+	if numSlashes > 1 {
+		return "", "", errors.New("expected mgmtDeviceName to be either in the format <mgmtBusName>/<mgmtDeviceName> or <mgmtDeviceName>")
+	} else if numSlashes == 0 {
+		return "", fullMgmtDeviceName, nil
+	} else {
+		values := strings.Split(fullMgmtDeviceName, "/")
+		return values[0], values[1], nil
+	}
+}
+
+/*AddVdpaDevice adds a new vdpa device to the given management device */
+func AddVdpaDevice(mgmtDeviceName string, vdpaDeviceName string) error {
+	if mgmtDeviceName == "" || vdpaDeviceName == "" {
+		return unix.EINVAL
+	}
+
+	busName, mgmtDeviceName, err := extractBusNameAndMgmtDeviceName(mgmtDeviceName)
+	if err != nil {
+		return unix.EINVAL
+	}
+
+	var attributes []*nl.RtAttr
+	var busNameAttr *nl.RtAttr
+	if busName != "" {
+		busNameAttr, err = GetNetlinkOps().NewAttribute(VdpaAttrMgmtDevBusName, busName)
+		if err != nil {
+			return err
+		}
+		attributes = append(attributes, busNameAttr)
+	}
+
+	mgmtAttr, err := GetNetlinkOps().NewAttribute(VdpaAttrMgmtDevDevName, mgmtDeviceName)
+	if err != nil {
+		return err
+	}
+	attributes = append(attributes, mgmtAttr)
+
+	nameAttr, err := GetNetlinkOps().NewAttribute(VdpaAttrDevName, vdpaDeviceName)
+	if err != nil {
+		return err
+	}
+	attributes = append(attributes, nameAttr)
+
+	_, err = GetNetlinkOps().RunVdpaNetlinkCmd(VdpaCmdDevNew, unix.NLM_F_ACK|unix.NLM_F_REQUEST, attributes)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func parseDevLinkVdpaDevList(msgs [][]byte) ([]VdpaDevice, error) {

--- a/pkg/kvdpa/netlink.go
+++ b/pkg/kvdpa/netlink.go
@@ -105,7 +105,7 @@ func (defaultNetlinkOps) NewAttribute(attrType int, data interface{}) (*nl.RtAtt
 	case VdpaAttrMgmtDevBusName, VdpaAttrMgmtDevDevName, VdpaAttrDevName:
 		strData, ok := data.(string)
 		if !ok {
-			return nil, fmt.Errorf("Attribute type %d requires string data", attrType)
+			return nil, fmt.Errorf("attribute type %d requires string data", attrType)
 		}
 		bytes := make([]byte, len(strData)+1)
 		copy(bytes, strData)
@@ -129,7 +129,7 @@ func (defaultNetlinkOps) NewAttribute(attrType int, data interface{}) (*nl.RtAtt
 		    VdpaAttrGetNetCfgMTU      u16
 		*/
 	default:
-		return nil, fmt.Errorf("Invalid attribute type %d", attrType)
+		return nil, fmt.Errorf("invalid attribute type %d", attrType)
 	}
 
 }

--- a/pkg/kvdpa/virtio.go
+++ b/pkg/kvdpa/virtio.go
@@ -2,7 +2,6 @@ package kvdpa
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,7 +54,7 @@ func GetVirtioNetInPath(parentPath string) (VirtioNet, error) {
 			}
 			var netdev string
 			// Read the "net" directory in the virtio device path
-			netDeviceFiles, err := ioutil.ReadDir(filepath.Join(virtioDevPath, "net"))
+			netDeviceFiles, err := os.ReadDir(filepath.Join(virtioDevPath, "net"))
 			if err == nil && len(netDeviceFiles) == 1 {
 				netdev = strings.TrimSpace(netDeviceFiles[0].Name())
 			}


### PR DESCRIPTION
This PR extends the govdpa library by adding the following capabilities:

- kvdpa-cli: Add support for new VdpaDevice
        This change allows the user (cli) to create a new VDPA device
        CLI command: kvdpa-cli add [mgmtdev] [dev]
             mgmtdev: the VDPA management device (e.g. pci/0000:65:00.2)
             dev:          the VDPA device (e.g. vdpa1)

- kvdpa-cli: Delete support for VdpaDevice
        This change allows the user (cli) to delete a VDPA device
        CLI command: kvdpa-cli del [dev]
             dev:     the VDPA device (e.g. vdpa1)

- Added function for returning the VdpaDevice objects for a given pciAddress
         function name: GetVdpaDevicesByPciAddress
         arguments: pciAddress string
         return values: []VdpaDevice, error
