### PR TITLE
ci: upgrade golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.40.1
+        version: v1.50.0
         skip-go-installation: true
         skip-pkg-cache: true
         skip-build-cache: true


### PR DESCRIPTION
Upgrade to 1.51 to avoid some warnings that are being triggered on dependency packages.