### PR TITLE
Internal refactoring to avoid unneeded netlink parsing

### DIFF
--- a/pkg/kvdpa/util.go
+++ b/pkg/kvdpa/util.go
@@ -1,0 +1,22 @@
+package kvdpa
+
+import (
+	"errors"
+	"strings"
+)
+
+// ExtractBusAndMgmtDevice extracts the busName and deviceName from a full device address (e.g. pci)
+// example 1: pci/65:0000.1   -> "pci", "65:0000.1",  nil
+// example 2: vdpa_sim        -> "",    "vdpa_sim",   nil
+// example 3: pci/65:0000.1/1 -> "",    "",           err
+func ExtractBusAndMgmtDevice(fullMgmtDeviceName string) (busName string, mgmtDeviceName string, err error) {
+	numSlashes := strings.Count(fullMgmtDeviceName, "/")
+	if numSlashes > 1 {
+		return "", "", errors.New("expected mgmtDeviceName to be either in the format <mgmtBusName>/<mgmtDeviceName> or <mgmtDeviceName>")
+	} else if numSlashes == 0 {
+		return "", fullMgmtDeviceName, nil
+	} else {
+		values := strings.Split(fullMgmtDeviceName, "/")
+		return values[0], values[1], nil
+	}
+}

--- a/pkg/kvdpa/util_test.go
+++ b/pkg/kvdpa/util_test.go
@@ -1,0 +1,53 @@
+package kvdpa
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractBusAndMgmtDevice(t *testing.T) {
+	tests := []struct {
+		testName      string
+		deviceAddress string
+		busName       string
+		devName       string
+		err           bool
+	}{
+		{
+			testName:      "regular PCI address",
+			deviceAddress: "pci/0000:65:00.1",
+			busName:       "pci",
+			devName:       "0000:65:00.1",
+			err:           false,
+		},
+		{
+			testName:      "no bus",
+			deviceAddress: "vdpa_sim",
+			busName:       "",
+			devName:       "vdpa_sim",
+			err:           false,
+		},
+		{
+			testName:      "wrong address",
+			deviceAddress: "pci/0000:65:00.1/0",
+			busName:       "",
+			devName:       "",
+			err:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s_%s", "TestExtractBusAndMgmtDevice", tt.testName), func(t *testing.T) {
+			busName, devName, err := ExtractBusAndMgmtDevice(tt.deviceAddress)
+			if tt.err {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.busName, busName)
+				assert.Equal(t, tt.devName, devName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Internal refactoring to avoid unneeded netlink parsing
The parsing of some netlink structures is performed only for those vdpa objects
that need to be returned to the user.
